### PR TITLE
Native CAS for C Rubies

### DIFF
--- a/atomic.gemspec
+++ b/atomic.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name = %q{atomic}
   s.version = "0.0.4"
   s.authors = ["Charles Oliver Nutter", "MenTaLguY"]
-  s.date = Time.now.strftime('YYYY-MM-DD')
+  s.date = Time.now.strftime('%Y-%m-%d')
   s.description = "An atomic reference implementation for JRuby and green or GIL-threaded impls"
   s.email = ["headius@headius.com", "mental@rydia.net"]
   s.files = Dir['{lib,examples,test,ext}/**/*'] + Dir['{*.txt,*.gemspec,Rakefile}']
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = "An atomic reference implementation for JRuby and green or GIL-threaded impls"
   s.test_files = Dir["test/test*.rb"]
+  s.extensions = 'ext/extconf.rb'
 end

--- a/ext/atomic_reference.c
+++ b/ext/atomic_reference.c
@@ -1,7 +1,7 @@
 #include <ruby.h>
 
 static void ir_mark(void *value) {
-  rb_mark((VALUE)value);
+  rb_gc_mark((VALUE)value);
 }
 
 static VALUE ir_alloc(VALUE klass) {

--- a/ext/atomic_reference.c
+++ b/ext/atomic_reference.c
@@ -29,15 +29,19 @@ static VALUE ir_get_and_set(VALUE self, VALUE new_value) {
   return old_value;
 }
 
-static VALUE ir_compare_and_set(VALUE self, VALUE expect_value, VALUE new_value) {
-  VALUE old_value;
-  old_value = (VALUE)DATA_PTR(self);
-  if (old_value == expect_value) {
-    DATA_PTR(self) = (void *)new_value;
+static VALUE ir_compare_and_set(volatile VALUE self, VALUE expect_value, VALUE new_value) {
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+  if (OSAtomicCompareAndSwap64(expect_value, new_value, &DATA_PTR(self))) {
     return Qtrue;
-  } else {
-    return Qfalse;
   }
+#elif (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) > 40100
+  if (__sync_bool_compare_and_swap(&DATA_PTR(self), expect_value, new_value)) {
+    return Qtrue;
+  }
+#else
+# error No CAS operation available for this platform
+#endif
+  return Qfalse;
 }
 
 void Init_atomic_reference() {


### PR DESCRIPTION
This patch fixes the gemspec file to actually use the C implementation on MRI, fixes a wrong function call in the C code, and attempts to provide real atomic CAS without depending on external libraries.

The latter would be supported on OSX and systems with GCC >= 4.1. Tested on OSX 10.6 and Debian lenny using MRI 1.9.2-p136.
