### PR TITLE
Just added some benchmarks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,11 @@ Rake::TestTask.new :test do |t|
   t.test_files = FileList["test/**/*.rb"]
 end
 
+desc "Run benchmarks"
+task :bench do
+  exec "ruby -Ilib -Iext test/bench_atomic.rb"
+end
+
 if defined?(JRUBY_VERSION)
   require 'ant'
 

--- a/test/bench_atomic.rb
+++ b/test/bench_atomic.rb
@@ -1,0 +1,29 @@
+require 'benchmark'
+require 'atomic'
+require 'thread'
+
+N = 100_000
+@lock = Mutex.new
+@atom = Atomic.new(0)
+
+Benchmark.bm(10) do |x|
+  x.report "simple" do
+    value = 0
+    N.times do
+      value += 1
+    end
+  end
+  x.report "mutex" do
+    value = 0
+    N.times do
+      @lock.synchronize do
+        value += 1
+      end
+    end
+  end
+  x.report "atomic" do
+    N.times do
+      @atom.update{|x| x += 1}
+    end
+  end
+end


### PR DESCRIPTION
I was just wondering how costly it was in comparison with mutexes in sequencial access.

my numbers on mri 1.9.2 for 100k increments of 1:

```
                user     system      total        real
simple      0.020000   0.000000   0.020000 (  0.013406)
mutex       0.060000   0.000000   0.060000 (  0.066982)
atomic      0.180000   0.000000   0.180000 (  0.187191)
```

The overhead does not look really significant but there is no performance advantage over mutexes on sequencial access.

I know. This was the easy part. Next I need to test the same operation but in parallel over a varying number of threads.

Some other ideas:
- propose common atomic operations like incr/decr (like redis)
- freeze mutable objects to avoid bad surprises
