### PR TITLE
Fix Atomic::InternalReference allocation

### DIFF
--- a/ext/atomic_reference.c
+++ b/ext/atomic_reference.c
@@ -1,7 +1,7 @@
 #include <ruby.h>
 
 static void ir_mark(void *value) {
-  rb_gc_mark((VALUE)value);
+  rb_gc_mark_maybe((VALUE)value);
 }
 
 static VALUE ir_alloc(VALUE klass) {
@@ -51,7 +51,8 @@ void Init_atomic_reference() {
   cAtomic = rb_const_get(rb_cObject, rb_intern("Atomic"));
   cInternalReference = rb_define_class_under(cAtomic, "InternalReference",
                                              rb_cObject);
-  rb_define_alloc_func(cAtomic, ir_alloc);
+
+  rb_define_alloc_func(cInternalReference, ir_alloc);
 
   rb_define_method(cInternalReference, "initialize", ir_initialize, 1);
   rb_define_method(cInternalReference, "get", ir_get, 0);


### PR DESCRIPTION
Moves the ir_alloc method to be the allocator for
Atomic::InternalReference instead of Atomic.

Fixes segfault when referencing a type that is not immediate (Fixes #11).
