### PR TITLE
Fix -march-i686 not supported in Ubuntu 12.04 LTS

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -18,7 +18,7 @@ case CONFIG["arch"]
 when /mswin32|mingw|solaris/
     $CFLAGS += " -march=native"
 when 'i686-linux'
-    $CFLAGS += " -march-i686"
+    $CFLAGS += " -march=i686"
 end
 
 try_run(<<CODE,$CFLAGS) && ($defs << '-DHAVE_GCC_CAS')


### PR DESCRIPTION
I believe the -march-i686 is outdated switch, see below as reference
http://gcc.gnu.org/onlinedocs/gcc/i386-and-x86_002d64-Options.html

```
root@eric:/usr/local/rvm/gems/ruby-1.9.3-p392/gems/atomic-1.1.11/ext# cat mkmf.log 
"gcc -o conftest -I/usr/local/rvm/rubies/ruby-1.9.3-p392/include/ruby-1.9.1/i686-linux -I/usr/local/rvm/rubies/ruby-1.9.3-p392/include/ruby-1.9.1/ruby/backward -I/usr/local/rvm/rubies/ruby-1.9.3-p392/include/ruby-1.9.1 -I.  -D_FILE_OFFSET_BITS=64  -I/usr/local/rvm/usr/include  -O3 -ggdb -Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration  -fPIC -march-i686 conftest.c  -L. -L/usr/local/rvm/rubies/ruby-1.9.3-p392/lib -Wl,-R/usr/local/rvm/rubies/ruby-1.9.3-p392/lib -L/usr/local/rvm/usr/lib -Wl,-R/usr/local/rvm/usr/lib -L.  -rdynamic -Wl,-export-dynamic -L/usr/local/rvm/usr/lib  -Wl,-R/usr/local/rvm/usr/lib      -Wl,-R -Wl,/usr/local/rvm/rubies/ruby-1.9.3-p392/lib -L/usr/local/rvm/rubies/ruby-1.9.3-p392/lib -lruby  -lpthread -lrt -ldl -lcrypt -lm   -lc"
cc1: error: unrecognized command line option ‘-march-i686’
```
