### PR TITLE
Adding Solaris support for atomic operations based on the comment at:

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -14,11 +14,13 @@ require 'mkmf'
 extension_name = 'atomic_reference'
 dir_config(extension_name)
 
-case CONFIG["arch"]
-when /mswin32|mingw|solaris/
-    $CFLAGS += " -march=native"
-when 'i686-linux'
-    $CFLAGS += " -march=i686"
+if CONFIG["GCC"] && CONFIG["GCC"] != ""
+  case CONFIG["arch"]
+  when /mswin32|mingw|solaris/
+      $CFLAGS += " -march=native"
+  when 'i686-linux'
+      $CFLAGS += " -march=i686"
+  end
 end
 
 try_run(<<CODE,$CFLAGS) && ($defs << '-DHAVE_GCC_CAS')


### PR DESCRIPTION
These small changes add Sun Studio support for SPARC and Intel-compatible architectures.  This should fix issues #29 and #30.
