### PR TITLE
include libkern/OSAtomic if available

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@
 
 require 'rake'
 require 'rake/testtask'
+require "rake/extensiontask"
 
 task :default => :test
 
@@ -50,16 +51,13 @@ if defined?(JRUBY_VERSION)
     ant.jar :basedir => "pkg/classes", :destfile => "lib/atomic_reference.jar", :includes => "**/*.class"
   end
 
-  task :package => :jar
+  task :compile => :jar
 else
-  task :package do
-    Dir.chdir("ext") do
-      # this does essentially the same thing
-      # as what RubyGems does
-      ruby "extconf.rb"
-      sh "make"
-    end
+  Rake::ExtensionTask.new "atomic" do |ext|
+    ext.ext_dir = 'ext'
+    ext.name ='atomic_reference'
   end
 end
 
-task :test => :package
+task :package => :compile
+task :test => :compile

--- a/ext/atomic_reference.c
+++ b/ext/atomic_reference.c
@@ -15,6 +15,10 @@
 #include <atomic.h>
 #endif
 
+#ifdef HAVE_LIBKERN_OSATOMIC_H
+#include <libkern/OSAtomic.h>
+#endif
+
 static void ir_mark(void *value) {
     rb_gc_mark_maybe((VALUE) value);
 }

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -14,6 +14,8 @@ require 'mkmf'
 extension_name = 'atomic_reference'
 dir_config(extension_name)
 
+have_header "libkern/OSAtomic.h"
+
 if CONFIG["GCC"] && CONFIG["GCC"] != ""
   case CONFIG["arch"]
   when /mswin32|mingw|solaris/

--- a/test/test_atomic.rb
+++ b/test/test_atomic.rb
@@ -10,10 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'test/unit'
+require 'minitest/autorun'
 require 'atomic'
 
-class TestAtomic < Test::Unit::TestCase
+class TestAtomic < MiniTest::Test
   def test_construct
     atomic = Atomic.new
     assert_equal nil, atomic.value
@@ -58,7 +58,7 @@ class TestAtomic < Test::Unit::TestCase
   def test_try_update_fails
     # use a number outside JRuby's fixnum cache range, to ensure identity is preserved
     atomic = Atomic.new(1000)
-    assert_raise Atomic::ConcurrentUpdateError do
+    assert_raises Atomic::ConcurrentUpdateError do
       # assigning within block exploits implementation detail for test
       atomic.try_update{|v| atomic.value = 1001 ; v + 1}
     end


### PR DESCRIPTION
I added [rake-compile](https://github.com/luislavena/rake-compiler) to manage compilation on the C side (it can do the Java side too, I just haven't figured it out yet).  Also, I couldn't get the extension to compile because it wasn't including libkern/OSAtomic.h, so I fixed that.  Also test/unit wasn't working with trunk ruby, so I switched it to minitest.
