### PR TITLE
Allow for better detection of gcc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.*.sw?
 lib/atomic_reference.jar
 /nbproject
 ext/*.bundle

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -16,7 +16,19 @@ dir_config(extension_name)
 
 have_header "libkern/OSAtomic.h"
 
-if CONFIG["GCC"] && CONFIG["GCC"] != ""
+def compiler_is_gcc
+  if CONFIG["GCC"] && CONFIG["GCC"] != ""
+    return true
+  elsif ( # This could stand to be more generic...  but I am afraid.
+    CONFIG["CC"] =~ /\bgcc\b/
+  )
+    return true
+  end
+  return false
+end
+
+
+if compiler_is_gcc
   case CONFIG["arch"]
   when /mswin32|mingw|solaris/
       $CFLAGS += " -march=native"


### PR DESCRIPTION
This request should fix #40.  My last pull request only detected GCC via

``` ruby
CONFIG['GCC']
```

This request will also inspect

``` ruby
CONFIG['CC']
```

Finally, I've added Vim swap files to the ignore list.
