### PR TITLE
Add build tasks for Windows fat binary gems for use with the RubyInstaller.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,13 @@ Building
 ========
 
 As of 1.1.0, JDK8 is required to build the atomic gem, since it attempts to use the new atomic Unsafe.getAndSetObject method only in JDK8. The resulting code should still work fine as far back as Java 5.
+
+Windows fat binary gems for use with the RubyInstaller can be built per cross compiler, provided that proper cross-rubies are installed. The recommented way is to use the [rake-compiler-dev-box](https://github.com/tjschuck/rake-compiler-dev-box):
+
+```sh
+cd /vagrant
+bin/prepare_xrubies
+git clone https://github.com/headius/ruby-atomic.git
+cd ruby-atomic
+rake cross native gem RUBY_CC_VERSION=1.9.3:2.0.0
+```

--- a/Rakefile
+++ b/Rakefile
@@ -53,9 +53,12 @@ if defined?(JRUBY_VERSION)
   task :compile => :jar
 else
   require "rake/extensiontask"
-  Rake::ExtensionTask.new "atomic" do |ext|
+  spec = Gem::Specification.load 'atomic.gemspec'
+  Rake::ExtensionTask.new "atomic", spec do |ext|
     ext.ext_dir = 'ext'
     ext.name ='atomic_reference'
+    ext.cross_compile = true
+    ext.cross_platform = ['x86-mingw32', 'x64-mingw32']
   end
 end
 

--- a/lib/atomic/ruby.rb
+++ b/lib/atomic/ruby.rb
@@ -10,6 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'atomic_reference'
+begin
+  RUBY_VERSION =~ /(\d+.\d+)/
+  require "#{$1}/atomic_reference"
+rescue LoadError
+  require 'atomic_reference'
+end
 require 'atomic/direct_update'
 require 'atomic/numeric_cas_wrapper'


### PR DESCRIPTION
atomic is the only dependent gem for rails-4.0, that requires the RubyInstaller DevKit in order to install the gem. It would be nice to allow an installation without DevKit by providing fat binary gems for x64-mingw32 and x86-mingw32 targets.

If you don't want to suffer with windows build stuff, I could also do the build and provide the resulting gem after each release. I do this for several other projects already.
