### PR TITLE
Update test suite to Minitest 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem 'rake-compiler'
-gem 'minitest', :group => :development
+gem 'minitest', '>= 5.0.0', :group => :development

--- a/test/test_atomic.rb
+++ b/test/test_atomic.rb
@@ -13,7 +13,7 @@
 require 'minitest/autorun'
 require 'atomic'
 
-class TestAtomic < MiniTest::Test
+class TestAtomic < Minitest::Test
   def test_construct
     atomic = Atomic.new
     assert_equal nil, atomic.value


### PR DESCRIPTION
Could we update to Minitest 5 already for the test suite? This would have come eventually I think. Thanks.
